### PR TITLE
(GH-3) Add StyleCop analyzer to test assemebly

### DIFF
--- a/src/Cake.Prca.Issues.MsBuild.Tests.ruleset
+++ b/src/Cake.Prca.Issues.MsBuild.Tests.ruleset
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Ruleset for Cake.Prca.Issues.MsBuild test cases" Description="Rules valid for Cake.Prca.Issues.MsBuild test cases" ToolsVersion="14.0">
+  <Include Path="Cake.Prca.Issues.MsBuild.ruleset" Action="Default" />
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1118" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+  </Rules>
+</RuleSet>

--- a/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\..\..\Cake.Prca\src\Cake.Prca.Tests.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\..\Cake.Prca\src\Cake.Prca.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -102,6 +104,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Testfiles\IssueWithOnlyFileName.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Cake.Prca.Issues.MsBuild.Tests/MsBuildCodeAnalysisProviderFixture.cs
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/MsBuildCodeAnalysisProviderFixture.cs
@@ -7,17 +7,16 @@
 
     public class MsBuildCodeAnalysisProviderFixture
     {
-
         public MsBuildCodeAnalysisProviderFixture(string fileResourceName)
         {
             this.Log = new FakeLog();
-            Log.Verbosity = Verbosity.Normal;
+            this.Log.Verbosity = Verbosity.Normal;
 
             using (var stream = this.GetType().Assembly.GetManifestResourceStream("Cake.Prca.Issues.MsBuild.Tests.Testfiles." + fileResourceName))
             {
                 using (var sr = new StreamReader(stream))
                 {
-                    this.Settings = 
+                    this.Settings =
                         MsBuildCodeAnalysisSettings.FromContent(
                             sr.ReadToEnd(),
                             new XmlFileLoggerFormat(this.Log),

--- a/src/Cake.Prca.Issues.MsBuild.Tests/MsBuildCodeAnalysisProviderTests.cs
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/MsBuildCodeAnalysisProviderTests.cs
@@ -11,12 +11,13 @@
             public void Should_Throw_If_Log_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => 
+                var result = Record.Exception(() =>
                     new MsBuildCodeAnalysisProvider(
-                        null, 
+                        null,
                         MsBuildCodeAnalysisSettings.FromContent(
-                            "Foo", 
-                            new XmlFileLoggerFormat(new FakeLog()),  @"c:\src")));
+                            "Foo",
+                            new XmlFileLoggerFormat(new FakeLog()),
+                            @"c:\src")));
 
                 // Then
                 result.IsArgumentNullException("log");
@@ -27,7 +28,7 @@
             {
                 var result = Record.Exception(() =>
                     new MsBuildCodeAnalysisProvider(
-                        new FakeLog(), 
+                        new FakeLog(),
                         null));
 
                 // Then

--- a/src/Cake.Prca.Issues.MsBuild.Tests/MsBuildCodeAnalysisSettingsTests.cs
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/MsBuildCodeAnalysisSettingsTests.cs
@@ -17,7 +17,7 @@
             public void Should_Throw_If_LogFilePath_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => 
+                var result = Record.Exception(() =>
                     MsBuildCodeAnalysisSettings.FromFilePath(
                         null,
                         new XmlFileLoggerFormat(new FakeLog()),
@@ -101,7 +101,7 @@
             public void Should_Throw_If_Format_For_LogFileContent_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => 
+                var result = Record.Exception(() =>
                     MsBuildCodeAnalysisSettings.FromContent(
                         "foo",
                         null,
@@ -128,7 +128,7 @@
             [Fact]
             public void Should_Set_Property_Values_Passed_To_Constructor()
             {
-                // Given 
+                // Given
                 const string logFileContent = "foo";
                 var format = new XmlFileLoggerFormat(new FakeLog());
                 var repoRoot = new DirectoryPath(@"C:\");
@@ -165,7 +165,7 @@
                     }
 
                     // When
-                    var settings = 
+                    var settings =
                         MsBuildCodeAnalysisSettings.FromFilePath(
                             fileName,
                             new XmlFileLoggerFormat(new FakeLog()),
@@ -182,12 +182,17 @@
                     }
                 }
             }
+
             private static string ConvertFromUtf8(byte[] bytes)
             {
                 var enc = new UTF8Encoding(true);
                 var preamble = enc.GetPreamble();
+
                 if (preamble.Where((p, i) => p != bytes[i]).Any())
+                {
                     throw new ArgumentException("Not utf8-BOM");
+                }
+
                 return enc.GetString(bytes.Skip(preamble.Length).ToArray());
             }
         }

--- a/src/Cake.Prca.Issues.MsBuild.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("MsBuild support for Cake Pull Request Code Analysis Testcases")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/src/Cake.Prca.Issues.MsBuild.Tests/packages.config
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Cake.Prca" version="0.1.0-beta0001" targetFramework="net452" />
   <package id="Cake.Testing" version="0.18.0" targetFramework="net452" />
   <package id="Shouldly" version="2.8.2" targetFramework="net452" />
+  <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />

--- a/src/Cake.Prca.Issues.MsBuild.ruleset
+++ b/src/Cake.Prca.Issues.MsBuild.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Ruleset for Cake.Prca" Description="Rules valid for Cake.Prca" ToolsVersion="14.0">
+<RuleSet Name="Ruleset for Cake.Prca.Issues.MsBuild" Description="Rules valid for Cake.Prca.Issues.MsBuild" ToolsVersion="14.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1000" Action="None" />

--- a/src/Cake.Prca.Issues.MsBuild/Cake.Prca.Issues.MsBuild.csproj
+++ b/src/Cake.Prca.Issues.MsBuild/Cake.Prca.Issues.MsBuild.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cake.Prca.Issues.MsBuild.XML</DocumentationFile>
-    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.Tests.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cake.Prca.Issues.MsBuild.XML</DocumentationFile>
-    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.Tests.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Cake.Prca.Issues.MsBuild/Cake.Prca.Issues.MsBuild.csproj
+++ b/src/Cake.Prca.Issues.MsBuild/Cake.Prca.Issues.MsBuild.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cake.Prca.Issues.MsBuild.XML</DocumentationFile>
-    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cake.Prca.Issues.MsBuild.XML</DocumentationFile>
-    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.Tests.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Adds StyleCop analyzer to test assemebly and defines separate ruleset for test assemblies with less strict validation.

Fixes #3 