### PR TITLE
(GH-11) Build against Cake 0.16.2 instead of 0.18

### DIFF
--- a/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
@@ -40,7 +40,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Prca, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Prca.0.2.0\lib\net45\Cake.Prca.dll</HintPath>
+      <HintPath>..\packages\Cake.Prca.0.2.1\lib\net45\Cake.Prca.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Testing, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
@@ -35,16 +35,16 @@
     <CodeAnalysisRuleSet>..\Cake.Prca.Issues.MsBuild.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.18.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.16.2\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Prca, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Cake.Prca.0.2.0\lib\net45\Cake.Prca.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Testing, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Testing.0.18.0\lib\net45\Cake.Testing.dll</HintPath>
+    <Reference Include="Cake.Testing, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.16.2\lib\net45\Cake.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">

--- a/src/Cake.Prca.Issues.MsBuild.Tests/packages.config
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.18.0" targetFramework="net452" />
+  <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
   <package id="Cake.Prca" version="0.2.0" targetFramework="net452" />
-  <package id="Cake.Testing" version="0.18.0" targetFramework="net452" />
+  <package id="Cake.Testing" version="0.16.2" targetFramework="net452" />
   <package id="Shouldly" version="2.8.2" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />

--- a/src/Cake.Prca.Issues.MsBuild.Tests/packages.config
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
-  <package id="Cake.Prca" version="0.2.0" targetFramework="net452" />
+  <package id="Cake.Prca" version="0.2.1" targetFramework="net452" />
   <package id="Cake.Testing" version="0.16.2" targetFramework="net452" />
   <package id="Shouldly" version="2.8.2" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />

--- a/src/Cake.Prca.Issues.MsBuild/Cake.Prca.Issues.MsBuild.csproj
+++ b/src/Cake.Prca.Issues.MsBuild/Cake.Prca.Issues.MsBuild.csproj
@@ -37,8 +37,8 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.18.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.16.2\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Prca, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Cake.Prca.Issues.MsBuild/Cake.Prca.Issues.MsBuild.csproj
+++ b/src/Cake.Prca.Issues.MsBuild/Cake.Prca.Issues.MsBuild.csproj
@@ -42,7 +42,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Prca, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Prca.0.2.0\lib\net45\Cake.Prca.dll</HintPath>
+      <HintPath>..\packages\Cake.Prca.0.2.1\lib\net45\Cake.Prca.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Cake.Prca.Issues.MsBuild/packages.config
+++ b/src/Cake.Prca.Issues.MsBuild/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
-  <package id="Cake.Prca" version="0.2.0" targetFramework="net452" />
+  <package id="Cake.Prca" version="0.2.1" targetFramework="net452" />
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.AnalyzerPowerPack" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="1.1.0" targetFramework="net452" />

--- a/src/Cake.Prca.Issues.MsBuild/packages.config
+++ b/src/Cake.Prca.Issues.MsBuild/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.18.0" targetFramework="net452" />
+  <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
   <package id="Cake.Prca" version="0.2.0" targetFramework="net452" />
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.AnalyzerPowerPack" version="1.1.0" targetFramework="net452" />


### PR DESCRIPTION
Build against Cake 0.16.2 instead of 0.18 to improve compatibility with scripts using an older Cake version.

Fixes #11 