### PR TITLE
(GH-23) Make MsBuildCodeAnalysisProvider internal

### DIFF
--- a/src/Cake.Prca.Issues.MsBuild.Tests/MsBuildCodeAnalysisProviderFixture.cs
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/MsBuildCodeAnalysisProviderFixture.cs
@@ -5,7 +5,7 @@
     using Core.Diagnostics;
     using Testing;
 
-    public class MsBuildCodeAnalysisProviderFixture
+    internal class MsBuildCodeAnalysisProviderFixture
     {
         public MsBuildCodeAnalysisProviderFixture(string fileResourceName)
         {

--- a/src/Cake.Prca.Issues.MsBuild/MsBuildCodeAnalysisProvider.cs
+++ b/src/Cake.Prca.Issues.MsBuild/MsBuildCodeAnalysisProvider.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Provider for code analysis issues reported as MsBuild warnings.
     /// </summary>
-    public class MsBuildCodeAnalysisProvider : CodeAnalysisProvider
+    internal class MsBuildCodeAnalysisProvider : CodeAnalysisProvider
     {
         private readonly MsBuildCodeAnalysisSettings settings;
 


### PR DESCRIPTION
Make `MsBuildCodeAnalysisProvider` internal since it only should be called through the alias.

Fixes #23