### PR TITLE
(GH-24) Make XmlFileLoggerFormat internal

### DIFF
--- a/src/Cake.Prca.Issues.MsBuild/XmlFileLoggerFormat.cs
+++ b/src/Cake.Prca.Issues.MsBuild/XmlFileLoggerFormat.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// MsBuild log format as written by the <code>XmlFileLogger</code> class from MSBuild Extension Pack.
     /// </summary>
-    public class XmlFileLoggerFormat : LogFileFormat
+    internal class XmlFileLoggerFormat : LogFileFormat
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlFileLoggerFormat"/> class.


### PR DESCRIPTION
Make `XmlFileLoggerFormat` internal since it only should be called through the alias.

Fixes #24