### PR TITLE
(GH-44) Pass null for warnings belonging to a file but with line 0

### DIFF
--- a/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/Cake.Prca.Issues.MsBuild.Tests.csproj
@@ -110,6 +110,9 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Testfiles\IssueWithLineZero.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Cake.Prca.Issues.MsBuild.Tests/Testfiles/IssueWithLineZero.xml
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/Testfiles/IssueWithLineZero.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<build started="3/7/2017 8:31:20 AM">
+  <project file="c:\Source\Cake.Prca\Cake.Prca.shfbproj" started="9/7/2017 7:22:28 AM">
+    <warning code="BE0006" file="SHFB" line="0" column="0" started="9/7/2017 7:22:31 AM"><![CDATA[Unable to locate any documentation sources for 'c:\Source\Cake.Prca\Cake.Prca..csproj' (Configuration: Debug Platform: AnyCPU)]]></warning>
+  </project>
+</build>

--- a/src/Cake.Prca.Issues.MsBuild.Tests/XmlFileLoggerFormatTests.cs
+++ b/src/Cake.Prca.Issues.MsBuild.Tests/XmlFileLoggerFormatTests.cs
@@ -65,6 +65,27 @@
             }
 
             [Fact]
+            public void Should_Read_Issue_With_Line_Zero_Correct()
+            {
+                // Given
+                var fixture = new MsBuildIssuesProviderFixture("IssueWithLineZero.xml");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(1);
+                var issue = issues.Single();
+                CheckIssue(
+                    issue,
+                    @"SHFB",
+                    null,
+                    "BE0006",
+                    0,
+                    @"Unable to locate any documentation sources for 'c:\Source\Cake.Prca\Cake.Prca..csproj' (Configuration: Debug Platform: AnyCPU)");
+            }
+
+            [Fact]
             public void Should_Read_Issue_Without_File_Correct()
             {
                 // Given

--- a/src/Cake.Prca.Issues.MsBuild/XmlFileLoggerFormat.cs
+++ b/src/Cake.Prca.Issues.MsBuild/XmlFileLoggerFormat.cs
@@ -88,8 +88,8 @@
 
             line = int.Parse(lineValue, CultureInfo.InvariantCulture);
 
-            // Convert negative lines numbers to null
-            if (line < 0)
+            // Convert negative line numbers or line number 0 to null
+            if (line <= 0)
             {
                 line = null;
             }


### PR DESCRIPTION
Issues belonging to a file, but with line equals 0 should be created without a line reference

Fixes #44 